### PR TITLE
Only supply `suffix` to `join_` functions that support it

### DIFF
--- a/R/join_data.R
+++ b/R/join_data.R
@@ -51,7 +51,11 @@ joindata <- function(.data, imported_data,
         byfml <- sprintf(", by = c(%s)", col_names)
     }
 
-    suf <- paste0(", suffix = c('.", left, "', '.", right, "')")
+    if (join_method %in% c("left_join", "right_join", "full_join")) {
+        suf <- paste0(", suffix = c('.", left, "', '.", right, "')")
+    } else {
+        suf <- ""
+    }
 
     exp <- ~.DATA %>%
         .FUN(.IMP.BY.SUFFIX)


### PR DESCRIPTION
For compatibility with dplyr 1.1.0 which is stricter with the arguments it accepts.

This fixes an error with the dev version of dplyr that we plan to send to CRAN on January 26. A pre-emptive fix release of iNZightVIT would be helpful. Thanks!